### PR TITLE
Commit Lookup (Skips to Register When Possible), Spinner Buttons for …

### DIFF
--- a/apps/next/components/Register/Bottom.tsx
+++ b/apps/next/components/Register/Bottom.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import Info from '../../public/Info.svg'
 import Plus from '../../public/Plus.svg'
 import Image from 'next/image'
@@ -9,43 +9,39 @@ import {
   useContractWrite,
   usePrepareContractWrite,
 } from 'wagmi'
-import { BigNumber, ethers } from 'ethers'
+import { BigNumber, providers } from 'ethers'
 
-import ETHRegistarController from '../../src/pages/abi/FLRRegistrarController.json'
-import PublicResolver from '../../src/pages/abi/PublicResolver.json'
+import FLRRegistrarController from '@/pages/abi/FLRRegistrarController.json'
+import PublicResolver from '@/pages/abi/PublicResolver.json'
+import { MIN_COMMITMENT_AGE_SECS, MAX_COMMITMENT_AGE_SECS } from '@/constants/FLRRegistrarController'
 
 import web3 from 'web3-utils'
-const namehash = require('eth-ens-namehash')
 
-const Waiting = () => {
+const ETHERS_PROVIDER = new providers.JsonRpcProvider('https://flare-api.flare.network/ext/C/rpc');
+
+enum RegisterState {
+  Uncommitted,  // this is the default begin state (count => 0)
+  Committable,  // reflects if commit will succeed or not (if there's a valid commitment already or not)
+  Committing,   // committing transaction in progress
+  Waiting,      // committing transaction complete, waiting timer in progress (count => 1)
+  Unregistered, // timer complete, pending register transaction (count => 2)
+  Registering,  // registering transaction in progress
+  Registered    // registration complete (count => 3)
+}
+
+const ActionButton = ({ onClickFn, label } : { onClickFn: any, label: string }) => {
   return (
-    <>
-      <div className="flex justify-center items-center px-6 py-3 bg-[#F97316] h-12 rounded-lg">
-        <svg
-          aria-hidden="true"
-          className={`mr-2 w-4 h-4 text-[#ffffff] dark:text-gray-500 animate-spin fill-[#ffffff]`}
-          viewBox="0 0 100 101"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
-            fill="currentFill"
-          />
-          <path
-            d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
-            fill="#F97316"
-          />
-        </svg>
-        <p className="pl-2 text-white text-base font-semibold text-center">
-          Waiting
-        </p>
-      </div>
-    </>
+    <button
+      onClick={() => onClickFn()}
+      className="flex justify-center items-center px-6 py-3 bg-[#F97316] h-12 rounded-lg text-white px-auto hover:scale-105 transform transition duration-300 ease-out"
+    >
+      <p className="text-base font-semibold mr-2">{label}</p>
+      <Image className="h-4 w-4" src={Plus} alt="FNS" />
+    </button>
   )
 }
 
-const Committing = () => {
+const SpinnerButton = ({ label } : { label: string}) => {
   return (
     <>
       <div className="flex justify-center items-center px-6 py-3 bg-[#F97316] h-12 rounded-lg">
@@ -66,7 +62,7 @@ const Committing = () => {
           />
         </svg>
         <p className="pl-2 text-white text-base font-semibold text-center">
-          Committing
+          {label}
         </p>
       </div>
     </>
@@ -86,21 +82,40 @@ const ReqToRegister = ({
   count: number
   setCount: React.Dispatch<React.SetStateAction<number>>
 }) => {
-  const [registerReady, setRegisterReady] = useState(false)
-  const [isWaiting, setIsWaiting] = useState(false)
-  const [isCommitting, setIsCommitting] = useState(false)
-
-  //  ------ Wagmi -------
-
+  const [registerState, setRegisterState] = useState<RegisterState>(RegisterState.Uncommitted)
   const { address } = useAccount()
 
-  // console.log('regPeriod * 31536000', regPeriod * 31536000)
+  useEffect(() => {
+    setRegisterState(RegisterState.Uncommitted)
+  }, [result])
+
+  useEffect(() => {
+    switch(registerState) {
+      case RegisterState.Uncommitted: {
+        setCount(0)
+        break
+      }
+      case RegisterState.Waiting: {
+        setCount(1)
+        break
+      }
+      case RegisterState.Unregistered: {
+        setCount(2)
+        break
+      }
+      case RegisterState.Registered: {
+        setCount(3)
+        break
+      }
+    }
+  }, [registerState, setCount])
 
   const { data: commitmentHash, isFetched: isMakeCommitmentReady } =
     useContractRead({
-      address: ETHRegistarController.address as `0x${string}`,
-      abi: ETHRegistarController.abi,
+      address: FLRRegistrarController.address as `0x${string}`,
+      abi: FLRRegistrarController.abi,
       functionName: 'makeCommitment',
+      enabled: registerState === RegisterState.Uncommitted,
       args: [
         result as string,
         address as `0x${string}`,
@@ -112,25 +127,66 @@ const ReqToRegister = ({
         0,
       ],
       onSuccess(data: any) {
-        console.log('Success makeCommitment', data)
-        // console.log('Base', Number(data.base))
+        //console.log('Success makeCommitment', data)
       },
       onError(error) {
-        console.log('Error makeCommitment', error)
+        console.error('Error makeCommitment', error)
       },
     })
 
-  const { config: configCommit } = usePrepareContractWrite({
-    address: ETHRegistarController.address as `0x${string}`,
-    abi: ETHRegistarController.abi,
-    functionName: 'commit',
+  // Check if there's a pending commitment by the current wallet
+  useContractRead({
+    address: FLRRegistrarController.address as `0x${string}`,
+    abi: FLRRegistrarController.abi,
+    functionName: 'commitments',
     args: [commitmentHash],
     enabled: isMakeCommitmentReady,
-    onSuccess(data) {
-      console.log('Success prepare configCommit', data)
+    async onSuccess(data: any) {
+      // console.log('Pending Commits Checked!', data)
+      // console.log('Pending Commits Boolean Eval', data.isZero());
+
+      // If this read returns 0, that means there is no equivalent pending commit
+      // If this read returns 1, we need to wait any remaining time for the 1 minute timeout,
+      // then set the state to register
+      if(!data.isZero()) {
+        try {
+          const currentBlock = await ETHERS_PROVIDER.getBlockNumber()
+          const blockTimestamp = (await ETHERS_PROVIDER.getBlock(currentBlock)).timestamp
+          // console.log("blockTimestamp", blockTimestamp)
+
+          // Only move state to registered if the commit isn't too old
+          if(data.add(MAX_COMMITMENT_AGE_SECS).gt(blockTimestamp)) {
+            setRegisterState(RegisterState.Unregistered)
+          }
+        } catch (error) {
+          console.error("Error fetching block timestamp")
+        }
+
+        // TODO: Finish implementation of remaining timer, when data is between
+        //       MIN and MAX_COMMITMENT_AGE_SECS
+      }
+      // If the data is zero, that means no matching commitment was found, which means we can
+      // move to committable state, which prepares the write hook for commit
+      else {
+        setRegisterState(RegisterState.Committable)
+      }
     },
     onError(error) {
-      console.log('Error prepare configCommit', error)
+      console.error('Error read commitments', error)
+    },
+  })
+
+  const { config: configCommit } = usePrepareContractWrite({
+    address: FLRRegistrarController.address as `0x${string}`,
+    abi: FLRRegistrarController.abi,
+    functionName: 'commit',
+    args: [commitmentHash],
+    enabled: isMakeCommitmentReady && registerState === RegisterState.Committable,
+    onSuccess(data) {
+      // console.log('Success prepare configCommit', data)
+    },
+    onError(error) {
+      console.error('Error prepare configCommit', error)
     },
   })
 
@@ -138,11 +194,11 @@ const ReqToRegister = ({
   const { writeAsync: commit } = useContractWrite({
     ...configCommit,
     onSuccess(data) {
-      console.log('Success commit', data)
-      setIsCommitting(true)
+      // console.log('Success commit', data)
+      setRegisterState(RegisterState.Committing)
     },
     onError(error) {
-      console.log('Error commit', error)
+      console.error('Error commit', error)
     },
   })
 
@@ -151,43 +207,37 @@ const ReqToRegister = ({
       .then(async (tx) => {
         const receipt = await tx.wait()
         if (receipt.status == 1) {
-          console.log('Commit transaction succeeded!', receipt.logs)
-          setCount(count + 1)
-          setIsCommitting(false)
+          // console.log('Commit transaction succeeded!', receipt.logs)
+          setRegisterState(RegisterState.Waiting)
           wait()
           return
         }
         console.error('Commit transaction reverted!', receipt.logs)
-        setCount(0)
       })
       .catch(() => {
         console.error('User rejected approval!')
-        setCount(0)
       })
   }
 
   function wait() {
-    setIsWaiting(true)
     let counter = 1
     const intervalId = setInterval(function () {
-      console.log(`Waiting for ${counter} minute(s)`)
+      //console.log(`Waiting for ${counter} minute(s)`)
       counter++
       if (counter > 1) {
         clearInterval(intervalId)
-        console.log('Finished waiting!')
-        // setCount(count + 1)
-        setRegisterReady(true)
-        setIsWaiting(false)
+        //console.log('Finished waiting!')
+        setRegisterState(RegisterState.Unregistered)
       }
     }, 60000)
   }
 
   // Prepare Register
   const { config: configRegister } = usePrepareContractWrite({
-    address: ETHRegistarController.address as `0x${string}`,
-    abi: ETHRegistarController.abi,
+    address: FLRRegistrarController.address as `0x${string}`,
+    abi: FLRRegistrarController.abi,
     functionName: 'register',
-    enabled: registerReady,
+    enabled: registerState === RegisterState.Unregistered, //registerReady,
     args: [
       result as string,
       address as `0x${string}`,
@@ -200,36 +250,26 @@ const ReqToRegister = ({
     ],
     overrides: {
       from: address as `0x${string}`,
-      value: BigNumber.from(price),
+      value: BigNumber.from(price).add(BigNumber.from(price).div(100)),
       gasLimit: BigNumber.from(1000000),
     },
     onSuccess(data) {
-      console.log('Success prepare register', data)
-      setCount(count + 1)
+      //console.log('Success prepare register', data)
     },
     onError(error) {
-      console.log('Error prepare register', error)
-      setRegisterReady(false)
-      setCount(0)
+      console.error('Error prepare register', error)
     },
   })
-
-  // console.log('BigNumber.from(price)', BigNumber.from(price))
-  // console.log(
-  //   'ethers.utils.parseUnits(price, wei)',
-  //   ethers.utils.parseUnits(price, 'wei')
-  // )
-  // console.log('price', price)
 
   // Register
   const { writeAsync: register } = useContractWrite({
     ...configRegister,
     onSuccess(data) {
-      console.log('Success register', data)
-      setRegisterReady(false)
+      //console.log('Success register', data)
+      setRegisterState(RegisterState.Registering)
     },
     onError(error) {
-      console.log('Error register', error)
+      console.error('Error register', error)
     },
   })
 
@@ -238,54 +278,32 @@ const ReqToRegister = ({
       .then(async (tx) => {
         const receipt = await tx.wait()
         if (receipt.status == 1) {
-          console.log('Register transaction succeeded!', receipt.logs)
-          setRegisterReady(false)
-          setCount(count + 1)
+          //console.log('Register transaction succeeded!', receipt.logs)
+          setRegisterState(RegisterState.Registered)
           return
         }
         console.error('Register transaction reverted!', receipt.logs)
-        setCount(0)
       })
       .catch(() => {
         console.error('User rejected approval!')
-        setCount(0)
       })
   }
-
-  // console.log(object);
 
   return (
     <>
       <div className="mt-10 flex justify-center items-center w-full">
-        {registerReady ? (
-          <button
-            onClick={() => registerFunc()}
-            className="flex justify-center items-center px-6 py-3 bg-[#F97316] h-12 rounded-lg text-white px-auto hover:scale-105 transform transition duration-300 ease-out"
-          >
-            <p className="text-base font-semibold mr-2">Register</p>
-            <Image className="h-4 w-4" src={Plus} alt="FNS" />
-          </button>
-        ) : isWaiting ? (
-          <Waiting />
-        ) : isCommitting ? (
-          <Committing />
-        ) : (
-          <>
-            <button
-              onClick={() => commitFunc()}
-              className="flex justify-center items-center px-6 py-3 bg-[#F97316] h-12 rounded-lg text-white px-auto hover:scale-105 transform transition duration-300 ease-out"
-            >
-              <p className="text-base font-semibold mr-2">Commit</p>
-              <Image className="h-4 w-4" src={Plus} alt="FNS" />
-            </button>
-            {/* <button
-              onClick={() => registerFunc()}
-              className="flex justify-center items-center ml-4 px-6 py-3 bg-[#F97316] h-12 rounded-lg text-white px-auto hover:scale-105 transform transition duration-300 ease-out"
-            >
-              <p className="text-base font-semibold mr-2">Register</p>
-              <Image className="h-4 w-4" src={Plus} alt="FNS" />
-            </button> */}
-          </>
+        { registerState === RegisterState.Committable ? (
+          <ActionButton onClickFn={commitFunc} label={"Commit"}/>
+        ) : registerState === RegisterState.Committing ? (
+          <SpinnerButton label={"Committing"}/>
+        ) : registerState === RegisterState.Waiting ? (
+          <SpinnerButton label={"Waiting"}/>
+        ) : registerState === RegisterState.Unregistered ? (
+          <ActionButton onClickFn={registerFunc} label={"Register"}/>
+        ) : registerState === RegisterState.Registering ? (
+          <SpinnerButton label={"Registering"}/>
+        ) : /* Registered returns empty fragment because we don't need a button */ (
+          <></>
         )}
       </div>
     </>

--- a/apps/next/components/Register/index.tsx
+++ b/apps/next/components/Register/index.tsx
@@ -160,42 +160,6 @@ export default function Register({ result }: { result: string }) {
     signerOrProvider: signer,
   })
 
-  // Get gas fee
-  // useEffect(() => {
-  //   const getGas = async () => {
-  //     const makeCommitment = await contract?.makeCommitment(
-  //       result as string,
-  //       address as `0x${string}`,
-  //       BigNumber.from(regPeriod).mul(31556952),
-  //       web3.sha3(address as `0x${string}`),
-  //       PublicResolver.address as `0x${string}`,
-  //       [],
-  //       false,
-  //       0
-  //     )
-  //     const gasCommit = await contract?.estimateGas.commit(makeCommitment)
-  //     // const gasRegister = await contract?.estimateGas.register(
-  //     //   result as string,
-  //     //   address as `0x${string}`,
-  //     //   BigNumber.from(regPeriod).mul(31556952),
-  //     //   web3.sha3(address as `0x${string}`),
-  //     //   PublicResolver.address as `0x${string}`,
-  //     //   [],
-  //     //   false,
-  //     //   0
-  //     // )
-  //     console.log('gasCommit', Number(gasCommit))
-  //   }
-
-  //   if (isConnected) {
-  //     getGas()
-  //   }
-  // }, [isConnected])
-
-  //0.00117262
-  //0.219
-  //0.220 * 2 = 0.44
-
   const incrementYears = () => {
     if (regPeriod >= 999) return
     setRegPeriod(regPeriod + 1)

--- a/apps/next/src/constants/FLRRegistrarController.tsx
+++ b/apps/next/src/constants/FLRRegistrarController.tsx
@@ -1,0 +1,2 @@
+export const MIN_COMMITMENT_AGE_SECS : number = 60    // 1 minute
+export const MAX_COMMITMENT_AGE_SECS : number = 86400 // 24 hours


### PR DESCRIPTION
- Automatically looks for a matching commit to the connected wallet address, and moves to register stage iff the commitment has not expired
- Improved statefulness all around via enum state variable: reduces RPC overhead by only calling prepare hooks when in the proper state
- Reusable subcomponent, ActionButton, for re-used style with the only difference being the onClick function and the label
- Reusable subcomponent SpinnerButton for re-used style with the only difference being the the label
- All loading states now have a spinner button, including Register call
- Renamed ETHRegistrarController -> FLRRegistrarController
- Tie updates to the **count** React State to the new enum state, which improves code legibility and predictability
- Add 1% to the value sent during purchase so that we avoid failing on FLRRegistrarController::InsufficientValue. Any amount greater than the actual price is refunded to the sender automatically
- Removed extraneous old comments
- Removed extraneous old commented out code
- Added constants folder with hard-coded values present in FLRRegistrarController in order to prevent another RPC call when we already have limited overhead